### PR TITLE
Finalizza traduzioni i18n e aggiunge test di parità (sopra a #32)

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,10 @@
 en:
+  errors:
+    messages:
+      not_saved:
+        one: "1 error prevented saving:"
+        other: "%{count} errors prevented saving:"
+
   activerecord:
     models:
       expense: "Expense"
@@ -215,6 +221,7 @@ en:
       amount: "Amount"
       currency: "$"
       actions: "Actions"
+      distance: "km"
 
     messages:
       confirm_delete: "Are you sure you want to delete this item?"
@@ -291,6 +298,13 @@ en:
 
   devise:
     passwords:
+      new:
+        title: "Recover your password"
+        subtitle: "Enter the email address associated with your account: we will send you instructions to reset your password."
+        email_label: "Email"
+        email_placeholder: "Enter your email"
+        invalid_email: "Please enter a valid email address."
+        submit: "Send recovery instructions"
       edit:
         title: "Change your password"
         subtitle: "Enter your new password"
@@ -342,46 +356,6 @@ en:
         fiscal_code_label: "Tax code"
         fiscal_code_help: "Tax code"
         fiscal_code_title: "Tax code"
-      save: "Save"
-      submit: "Submit"
-      confirm: "Confirm"
-      delete: "Delete"
-      add: "Add"
-      remove: "Remove"
-      search: "Search"
-      filter: "Filter"
-      export: "Export"
-      import: "Import"
-      download: "Download"
-      upload: "Upload"
-
-    labels:
-      required: "required"
-      optional: "optional"
-      yes: "Yes"
-      no: "No"
-      total: "Total"
-      subtotal: "Subtotal"
-      date: "Date"
-      time: "Time"
-      description: "Description"
-      notes: "Notes"
-      status: "Status"
-      type: "Type"
-      amount: "Amount"
-      currency: "$"
-
-    messages:
-      confirm_delete: "Are you sure you want to delete this item?"
-      success_create: "Item created successfully"
-      success_update: "Item updated successfully"
-      success_delete: "Item deleted successfully"
-      error_create: "Error while creating item"
-      error_update: "Error while updating item"
-      error_delete: "Error while deleting item"
-      no_data: "No data available"
-      loading: "Loading..."
-    at_time: "at"
 
   rimborsi:
     expense_types:
@@ -439,9 +413,8 @@ en:
       italian: "Italian"
       english: "English"
 
-  roles:
-    role:
-      label: "Label"
+  reimboursement:
+    status: "Status"
 
   reimboursements:
     index:
@@ -637,9 +610,6 @@ en:
       edit_expense: "Edit expense"
       save_changes: "Save changes"
       car_expense_title: "Car expense - calculation details"
-      vehicle_label: "Vehicle:"
-      route_label: "Route:"
-      distance_label: "Distance:"
       costs_per_km: "Costs per km"
       quota_capitale: "Capital share:"
       carburante: "Fuel:"
@@ -656,7 +626,6 @@ en:
       amount_details: "Amount details"
       expense_amount: "Expense amount:"
       invoice_converted: "Invoice converted to PDF"
-      download_pdf: "Download PDF"
       original_xml: "Original XML file"
       pdf_auto_generated: "PDF automatically generated from electronic invoice"
       view_fullscreen: "View full screen"
@@ -677,7 +646,6 @@ en:
       set_waiting: "Pending"
       set_denied: "Denied"
       deny_default_hint: "By default the reimbursement is set to \"Pending\""
-      cancel: "Cancel"
       deny_submit: "Deny expense"
 
   bank_accounts:
@@ -692,7 +660,12 @@ en:
       town_th: "City"
       fiscal_code_th: "Tax code"
       default_th: "Default"
+      actions_th: "Actions"
       is_default: "Default"
+      not_default: "Not default"
+      view: "View"
+      edit: "Edit"
+      delete: "Delete"
       delete_confirm: "Are you sure you want to delete this bank account?"
       empty_title: "No bank accounts found"
       empty_text: "Start by adding your first bank account."
@@ -709,9 +682,13 @@ en:
       town_label: "City:"
       fiscal_code_label: "Tax code:"
       default_label: "Default:"
+      "yes": "Yes"
+      "no": "No"
+      edit: "Edit"
       back: "Back to list"
     new:
       title: "New bank account"
+      back: "Back"
     edit:
       title: "Edit bank account"
     form:
@@ -719,6 +696,7 @@ en:
       select_user: "Select user"
       iban_label: "IBAN"
       iban_help: "Enter the IBAN without spaces"
+      iban_placeholder: "IT00X0000000000000000000000"
       owner_label: "Account holder"
       owner_help: "Full name of the account holder"
       bank_name_label: "Bank name"
@@ -735,6 +713,8 @@ en:
       fiscal_code_help: "(optional)"
       default_label: "Default account"
       default_help: "If selected, this will become your default account (it will remove the default flag from all other bank accounts)"
+      save: "Save"
+      cancel: "Cancel"
 
   vehicles:
     index:
@@ -746,7 +726,11 @@ en:
       brand_model_th: "Brand and model"
       fuel_th: "Fuel"
       default_th: "Default"
+      actions_th: "Actions"
       is_default: "Default"
+      view: "View"
+      edit: "Edit"
+      delete: "Delete"
       delete_confirm: "Are you sure you want to delete this vehicle?"
       empty_title: "No vehicles found"
       empty_text: "Start by adding your first vehicle for car expenses."
@@ -760,6 +744,8 @@ en:
       model_label: "Model:"
       fuel_label: "Fuel type:"
       default_label: "Default:"
+      "yes": "Yes"
+      "no": "No"
       back: "Back to list"
     new:
       title: "New vehicle"
@@ -778,6 +764,8 @@ en:
       select_fuel: "Select fuel type"
       default_label: "Default vehicle"
       default_help: "If selected, this will become your default vehicle for car expenses"
+      save: "Save"
+      cancel: "Cancel"
 
   funds:
     index:
@@ -792,8 +780,13 @@ en:
       actions_th: "Actions"
       details_th: "Details"
       admin_only: "Admin only"
+      view: "View"
+      edit: "Edit"
+      delete: "Delete"
+      delete_confirm: "Are you sure you want to delete this fund?"
       empty_title: "No projects found"
     show:
+      edit: "Edit"
       back: "Back to projects"
       project_info: "Project information"
       name_label: "Name:"
@@ -843,6 +836,8 @@ en:
       create: "Create project"
 
   roles:
+    role:
+      label: "Label"
     index:
       title: "Roles"
       label_th: "Label"
@@ -892,6 +887,7 @@ en:
         payment_date_label: "Payment date:"
         created_label: "Created:"
         details: "Details"
+        edit: "Edit"
         retry: "Retry"
         retry_confirm: "Are you sure you want to retry processing?"
         empty_title: "No payments found"
@@ -922,6 +918,7 @@ en:
       new:
           title: "New payment"
           back_to_payments: "Back to payments"
+          cancel: "Cancel"
           details_header: "Payment details"
           errors_prevented: "%{count} errors prevented saving:"
           status_label: "Status"
@@ -970,6 +967,10 @@ en:
         role_th: "Role"
         status_th: "Status"
         reimbursements_th: "Reimbursements"
+        actions_th: "Actions"
+        view: "View"
+        edit: "Edit"
+        delete: "Delete"
         active: "Active"
         inactive: "Inactive"
         deactivate: "Deactivate"
@@ -980,6 +981,11 @@ en:
         has_reimbursements: "Has associated reimbursements"
       show:
         title: "User details"
+        "yes": "Yes"
+        "no": "No"
+        status:
+          active: "Active"
+          deactivated: "Deactivated"
         active: "Active"
         deactivated: "Deactivated"
         email_label: "Email:"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,4 +1,10 @@
 it:
+  errors:
+    messages:
+      not_saved:
+        one: "Si è verificato 1 errore che ha impedito il salvataggio:"
+        other: "Si sono verificati %{count} errori che hanno impedito il salvataggio:"
+
   activerecord:
     models:
       expense: "Spesa"
@@ -217,6 +223,7 @@ it:
       amount: "Importo"
       currency: "€"
       actions: "Azioni"
+      distance: "km"
       
     messages:
       confirm_delete: "Sei sicuro di voler eliminare questo elemento?"
@@ -354,6 +361,7 @@ it:
       initial_note_label: "Aggiungi una nota al rimborso"
       initial_note_placeholder: "Inserisci qui eventuali informazioni aggiuntive sul rimborso..."
       initial_note_help: "Questa nota sarà visibile alla segreteria e potrà aiutarli nella valutazione del rimborso."
+      cancel: "Annulla"
       submit: "Salva e invia rimborso"
       submit_hint: "Potrai modificare il rimborso anche dopo l'invio fino a quando non passerà in approvazione dalla segreteria."
       amount_placeholder: "Inserisci importo"
@@ -480,9 +488,6 @@ it:
       edit_expense: "Modifica Spesa"
       save_changes: "Salva Modifiche"
       car_expense_title: "Spesa Auto - Dettagli Calcolo"
-      vehicle_label: "Veicolo:"
-      route_label: "Percorso:"
-      distance_label: "Distanza:"
       costs_per_km: "Costi per Km"
       quota_capitale: "Quota capitale:"
       carburante: "Carburante:"
@@ -499,7 +504,6 @@ it:
       amount_details: "Dettagli Importo"
       expense_amount: "Importo spesa:"
       invoice_converted: "Fattura convertita in PDF"
-      download_pdf: "Scarica PDF"
       original_xml: "File XML Originale"
       pdf_auto_generated: "PDF generato automaticamente dalla fattura elettronica"
       view_fullscreen: "Visualizza a Schermo Intero"
@@ -534,7 +538,12 @@ it:
       town_th: "Città"
       fiscal_code_th: "Codice Fiscale"
       default_th: "Predefinito"
+      actions_th: "Azioni"
       is_default: "Predefinito"
+      not_default: "Non predefinito"
+      view: "Visualizza"
+      edit: "Modifica"
+      delete: "Elimina"
       delete_confirm: "Sei sicuro di voler eliminare questo conto bancario?"
       empty_title: "Nessun conto bancario trovato"
       empty_text: "Inizia aggiungendo il tuo primo conto bancario."
@@ -551,9 +560,13 @@ it:
       town_label: "Città:"
       fiscal_code_label: "Codice Fiscale:"
       default_label: "Predefinito:"
+      "yes": "Sì"
+      "no": "No"
+      edit: "Modifica"
       back: "Torna alla Lista"
     new:
       title: "Nuovo conto bancario"
+      back: "Indietro"
     edit:
       title: "Modifica conto bancario"
     form:
@@ -561,6 +574,7 @@ it:
       select_user: "Seleziona utente"
       iban_label: "IBAN"
       iban_help: "Inserisci l'IBAN senza spazi"
+      iban_placeholder: "IT00X0000000000000000000000"
       owner_label: "Intestatario"
       owner_help: "Nome completo del titolare del conto"
       bank_name_label: "Nome Banca"
@@ -577,6 +591,8 @@ it:
       fiscal_code_help: "(opzionale)"
       default_label: "Conto predefinito"
       default_help: "Se selezionato, questo diventerà il tuo conto predefinito (rimuoverà il flag da tutti gli altri conti bancari)"
+      save: "Salva"
+      cancel: "Annulla"
 
   vehicles:
     index:
@@ -588,7 +604,11 @@ it:
       brand_model_th: "Marca e Modello"
       fuel_th: "Carburante"
       default_th: "Predefinito"
+      actions_th: "Azioni"
       is_default: "Predefinito"
+      view: "Visualizza"
+      edit: "Modifica"
+      delete: "Elimina"
       delete_confirm: "Sei sicuro di voler eliminare questo veicolo?"
       empty_title: "Nessun veicolo trovato"
       empty_text: "Inizia aggiungendo il tuo primo veicolo per le spese auto."
@@ -602,6 +622,8 @@ it:
       model_label: "Modello:"
       fuel_label: "Tipo di carburante:"
       default_label: "Predefinito:"
+      "yes": "Sì"
+      "no": "No"
       back: "Torna alla Lista"
     new:
       title: "Nuovo Veicolo"
@@ -620,6 +642,8 @@ it:
       select_fuel: "Seleziona tipo di carburante"
       default_label: "Veicolo predefinito"
       default_help: "Se selezionato, questo diventerà il tuo veicolo predefinito per le spese auto"
+      save: "Salva"
+      cancel: "Annulla"
 
   funds:
     index:
@@ -634,8 +658,13 @@ it:
       actions_th: "Azioni"
       details_th: "Dettagli"
       admin_only: "Solo Admin"
+      view: "Visualizza"
+      edit: "Modifica"
+      delete: "Elimina"
+      delete_confirm: "Sei sicuro di voler eliminare questo fondo?"
       empty_title: "Nessun progetto trovato"
     show:
+      edit: "Modifica"
       back: "Torna ai Progetti"
       project_info: "Informazioni Progetto"
       name_label: "Nome:"
@@ -685,13 +714,15 @@ it:
       create: "Crea Progetto"
 
   roles:
+    role:
+      label: "Etichetta"
     index:
       title: "Ruoli"
-      label_th: "Label"
-      show: "Show"
-      edit: "Edit"
-      destroy: "Destroy"
-      destroy_confirm: "Are you sure?"
+      label_th: "Etichetta"
+      show: "Mostra"
+      edit: "Modifica"
+      destroy: "Elimina"
+      destroy_confirm: "Sei sicuro?"
       new: "Nuovo Ruolo"
     new:
       title: "Nuovo Ruolo"
@@ -700,6 +731,9 @@ it:
       title: "Modifica Ruolo"
       show: "Mostra"
       back: "Indietro"
+
+  reimboursement:
+    status: "Stato"
 
   notes:
     index:
@@ -729,6 +763,7 @@ it:
         reimbursement_singular: "rimborso"
         reimbursement_plural: "rimborsi"
         new: "Nuovo Pagamento"
+        edit: "Modifica"
         total_label: "Totale:"
         reimbursements_label: "Rimborsi:"
         payment_date_label: "Data pagamento:"
@@ -743,16 +778,6 @@ it:
         back: "Torna ai Pagamenti"
         edit: "Modifica"
         retry: "Riprova Processamento"
-    users:
-      edit:
-        title: "Modifica Utente: %{name} %{surname}"
-        fiscal_code_label: "Codice Fiscale"
-        fiscal_code_title: "Codice fiscale"
-        role_label: "Ruolo"
-        select_role_prompt: "Seleziona un ruolo"
-        account_active_label: "Account Attivo"
-        account_active_help: "Deseleziona per disattivare l'accesso dell'utente"
-        update_user: "Aggiorna Utente"
         retry_confirm: "Sei sicuro di voler ritentare il processamento?"
         details_header: "Dettagli Pagamento"
         id_label: "ID:"
@@ -762,7 +787,7 @@ it:
         payment_date_label: "Data pagamento:"
         reimbursements_count_label: "Rimborsi inclusi:"
         error_header: "Errore durante il processamento"
-        error_text: "Il cariamento di questo pagamento su NextCloud ha riscontrato degli errori. Utilizza il pulsante \"Riprova Processamento\" per ritentare l'operazione."
+        error_text: "Il caricamento di questo pagamento su NextCloud ha riscontrato degli errori. Utilizza il pulsante \"Riprova Processamento\" per ritentare l'operazione."
         included_header: "Rimborsi Inclusi"
         id_th: "ID"
         user_th: "Utente"
@@ -772,32 +797,33 @@ it:
         actions_th: "Azioni"
         na: "N/D"
       new:
-          title: "Nuovo Pagamento"
-          back_to_payments: "Torna ai Pagamenti"
-          details_header: "Dettagli Pagamento"
-          errors_prevented: "%{count} errori hanno impedito il salvataggio:"
-          status_label: "Stato"
-          status_created: "Creato"
-          status_help: "I nuovi pagamenti vengono sempre creati con stato \"Creato\""
-          reimbursements_label: "Rimborsi da Includere"
-          reimbursement_number: "Rimborso #%{id}"
-          selection_help: "Seleziona i rimborsi da includere in questo pagamento. Solo i rimborsi approvati con un conto bancario sono disponibili."
-          none_available_title: "Nessun rimborso disponibile"
-          none_available_text: "Non ci sono rimborsi approvati con conti bancari disponibili per creare un pagamento."
-          create_btn: "Crea Pagamento"
-          info_header: "Informazioni"
-          how_it_works_title: "Come funziona:"
-          how_it_works:
-            step1: "1. Seleziona i rimborsi approvati da includere"
-            step2: "2. Il totale verrà calcolato automaticamente"
-            step3: "3. Il pagamento viene creato con stato \"Creato\""
-            step4: "4. Segna il pagamento come \"Pagato\" per il caricamento dei dati in Nextcloud"
-            step5: "5. Scarica il flusso e caricalo in banca per i pagamenti"
-          available_title: "Disponibili:"
-          available_count_label: "rimborsi"
-          for_a_total: "per un totale di"
-          selected_total: "Totale selezionato:"
-          no_available_text: "Non ci sono rimborsi approvati con conti bancari disponibili per creare un pagamento."
+        title: "Nuovo Pagamento"
+        back_to_payments: "Torna ai Pagamenti"
+        cancel: "Annulla"
+        details_header: "Dettagli Pagamento"
+        errors_prevented: "%{count} errori hanno impedito il salvataggio:"
+        status_label: "Stato"
+        status_created: "Creato"
+        status_help: "I nuovi pagamenti vengono sempre creati con stato \"Creato\""
+        reimbursements_label: "Rimborsi da Includere"
+        reimbursement_number: "Rimborso #%{id}"
+        selection_help: "Seleziona i rimborsi da includere in questo pagamento. Solo i rimborsi approvati con un conto bancario sono disponibili."
+        none_available_title: "Nessun rimborso disponibile"
+        none_available_text: "Non ci sono rimborsi approvati con conti bancari disponibili per creare un pagamento."
+        create_btn: "Crea Pagamento"
+        info_header: "Informazioni"
+        how_it_works_title: "Come funziona:"
+        how_it_works:
+          step1: "1. Seleziona i rimborsi approvati da includere"
+          step2: "2. Il totale verrà calcolato automaticamente"
+          step3: "3. Il pagamento viene creato con stato \"Creato\""
+          step4: "4. Segna il pagamento come \"Pagato\" per il caricamento dei dati in Nextcloud"
+          step5: "5. Scarica il flusso e caricalo in banca per i pagamenti"
+        available_title: "Disponibili:"
+        available_count_label: "rimborsi"
+        for_a_total: "per un totale di"
+        selected_total: "Totale selezionato:"
+        no_available_text: "Non ci sono rimborsi approvati con conti bancari disponibili per creare un pagamento."
       edit:
         title: "Modifica Pagamento"
         back: "Torna al Pagamento"
@@ -822,6 +848,10 @@ it:
         role_th: "Ruolo"
         status_th: "Stato"
         reimbursements_th: "Rimborsi"
+        actions_th: "Azioni"
+        view: "Visualizza"
+        edit: "Modifica"
+        delete: "Elimina"
         active: "Attivo"
         inactive: "Disattivo"
         deactivate: "Disattiva"
@@ -832,6 +862,11 @@ it:
         has_reimbursements: "Ha dei rimborsi associati"
       show:
         title: "Dettagli Utente"
+        "yes": "Sì"
+        "no": "No"
+        status:
+          active: "Attivo"
+          deactivated: "Disattivato"
         active: "Attivo"
         deactivated: "Disattivato"
         email_label: "Email:"
@@ -855,13 +890,14 @@ it:
         has_reimbursements: "L'utente ha dei rimborsi associati"
         back: "Torna alla lista"
       edit:
-        title: "Modifica Utente"
+        title: "Modifica Utente: %{name} %{surname}"
         fiscal_code_label: "Codice Fiscale"
+        fiscal_code_title: "Codice fiscale"
         role_label: "Ruolo"
-        select_role: "Seleziona un ruolo"
-        active_label: "Account Attivo"
-        active_help: "Deseleziona per disattivare l'accesso dell'utente"
-        update_btn: "Aggiorna Utente"
+        select_role_prompt: "Seleziona un ruolo"
+        account_active_label: "Account Attivo"
+        account_active_help: "Deseleziona per disattivare l'accesso dell'utente"
+        update_user: "Aggiorna Utente"
 
   mailers:
     reimboursement:
@@ -926,6 +962,13 @@ it:
 
   devise:
     passwords:
+      new:
+        title: "Recupera la tua password"
+        subtitle: "Inserisci l'indirizzo email associato al tuo account: ti invieremo le istruzioni per reimpostare la password."
+        email_label: "Email"
+        email_placeholder: "Inserisci la tua email"
+        invalid_email: "Inserisci un indirizzo email valido."
+        submit: "Invia istruzioni di recupero"
       edit:
         title: "Cambia la tua password"
         subtitle: "Inserisci la tua nuova password"

--- a/test/controllers/set_locale_test.rb
+++ b/test/controllers/set_locale_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+require "ostruct"
+
+# Verifies ApplicationController#set_locale uses the user's locale
+# when present and falls back to I18n.default_locale otherwise.
+class SetLocaleTest < ActiveSupport::TestCase
+  self.fixture_table_names = []
+
+  class FakeController < ApplicationController
+    skip_before_action :authenticate_user!, raise: false
+    attr_accessor :stub_user
+    def current_user; stub_user; end
+    def trigger; set_locale; end
+  end
+
+  setup { @ctrl = FakeController.new }
+
+  test "uses user's locale when present" do
+    @ctrl.stub_user = OpenStruct.new(locale: "en")
+    @ctrl.trigger
+    assert_equal :en, I18n.locale
+  ensure
+    I18n.locale = I18n.default_locale
+  end
+
+  test "falls back to default when user is nil" do
+    @ctrl.stub_user = nil
+    I18n.locale = :en  # ensure it changes
+    @ctrl.trigger
+    assert_equal I18n.default_locale, I18n.locale
+  end
+
+  test "falls back to default when user has nil locale" do
+    @ctrl.stub_user = OpenStruct.new(locale: nil)
+    I18n.locale = :en
+    @ctrl.trigger
+    assert_equal I18n.default_locale, I18n.locale
+  end
+end

--- a/test/i18n_test.rb
+++ b/test/i18n_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+require "yaml"
+require "find"
+
+# Asserts that every t("...") call in the codebase resolves in both
+# locales, and that en.yml and it.yml have the same key set. Catches:
+#   - keys referenced from views/controllers but never defined
+#   - keys defined in one locale but missing in the other
+#   - duplicate top-level keys in YAML (silently overridden by Psych)
+#   - YAML 1.1 boolean traps (`yes:` / `no:` parsed as true/false)
+class I18nTest < ActiveSupport::TestCase
+  self.fixture_table_names = []
+
+  PLURAL_KEYS = %w[zero one two few many other].freeze
+  LOCALES = %w[en it].freeze
+  ROOT = Rails.root
+
+  def setup
+    @defined = LOCALES.each_with_object({}) do |loc, h|
+      raw = YAML.load_file(ROOT.join("config/locales/#{loc}.yml"))
+      h[loc] = flatten(raw[loc])
+    end
+  end
+
+  test "no duplicate top-level paths in YAML files" do
+    LOCALES.each do |loc|
+      dups = duplicate_paths(ROOT.join("config/locales/#{loc}.yml"))
+      assert_empty dups, "Duplicate keys in #{loc}.yml (silently overridden):\n  " + dups.map { |k, ls| "#{k} at lines #{ls.join(', ')}" }.join("\n  ")
+    end
+  end
+
+  test "en and it have the same key set" do
+    only_en = @defined["en"] - @defined["it"]
+    only_it = @defined["it"] - @defined["en"]
+    msg = []
+    msg << "Defined only in en (#{only_en.size}): #{only_en.sort.first(10).join(', ')}" if only_en.any?
+    msg << "Defined only in it (#{only_it.size}): #{only_it.sort.first(10).join(', ')}" if only_it.any?
+    assert only_en.empty? && only_it.empty?, msg.join("\n")
+  end
+
+  test "every t(...) reference resolves in both locales" do
+    referenced = referenced_keys
+    missing = LOCALES.each_with_object({}) do |loc, h|
+      h[loc] = referenced.reject { |k| has_key?(@defined[loc], k) }
+    end
+    if missing.any? { |_, ks| ks.any? }
+      msg = missing.map { |loc, ks| "#{loc} missing #{ks.size}: #{ks.sort.first(10).join(', ')}" }
+      flunk msg.join("\n")
+    end
+  end
+
+  private
+
+  def flatten(hash, prefix = nil, out = Set.new)
+    hash.each do |k, v|
+      full = [prefix, k].compact.join(".")
+      v.is_a?(Hash) ? flatten(v, full, out) : out << full
+    end
+    out
+  end
+
+  def has_key?(set, key)
+    set.include?(key) || PLURAL_KEYS.any? { |p| set.include?("#{key}.#{p}") }
+  end
+
+  def view_scope(path)
+    rel = path.sub(%r{^.*/app/views/}, "")
+    rel.sub(/\.[a-z]+\.erb$/, "").sub(/\.erb$/, "").gsub("/_", "/").tr("/", ".")
+  end
+
+  def referenced_keys
+    out = Set.new
+    static_re = /\bt[\s(]+(['"])([a-z][a-z0-9_.]*)\1/
+    lazy_re   = /\bt[\s(]+(['"])(\.[a-z0-9_.]+)\1/
+    %w[app/views app/controllers app/mailers app/helpers app/models].each do |dir|
+      Find.find(ROOT.join(dir).to_s) do |path|
+        next unless File.file?(path) && path =~ /\.(rb|erb)$/
+        body = File.read(path)
+        body.scan(static_re) { |_, key| out << key }
+        if path.include?("/app/views/")
+          scope = view_scope(path)
+          body.scan(lazy_re) { |_, key| out << scope + key }
+        end
+      end
+    end
+    out
+  end
+
+  # Walk the YAML file textually and detect duplicate paths.
+  # Psych silently picks one when paths collide; this catches that bug.
+  def duplicate_paths(path)
+    stack = []
+    seen = Hash.new { |h, k| h[k] = [] }
+    File.readlines(path).each_with_index do |line, idx|
+      next if line.strip.start_with?("#") || line.strip.empty?
+      next unless line =~ /^(\s*)([a-zA-Z_][\w\.]*|"[^"]+"):\s*(.*)$/
+      indent, key, value = $1.length, $2.tr('"', ""), $3
+      stack.pop while stack.last && stack.last[0] >= indent
+      full = stack.map { |_, k| k }.push(key).join(".")
+      seen[full] << idx + 1
+      stack << [indent, key] if value.empty?
+    end
+    seen.select { |_, ls| ls.size > 1 }
+  end
+end

--- a/test/models/user_locale_test.rb
+++ b/test/models/user_locale_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class UserLocaleTest < ActiveSupport::TestCase
+  self.fixture_table_names = []
+
+  def build_user(overrides = {})
+    User.new({
+      email: "loc#{SecureRandom.hex(4)}@example.com",
+      password: "password123",
+      password_confirmation: "password123",
+      name: "Mario",
+      surname: "Rossi",
+      fiscal_code: "RSSMRA80A01H501#{('A'..'Z').to_a.sample}"
+    }.merge(overrides))
+  end
+
+  # The locale column has a DB default of 'it', so even User.new without
+  # an explicit locale comes back with "it". The before_create callback
+  # in user.rb is essentially a backstop for the same behavior.
+  test "default locale is 'it' when not explicitly set" do
+    user = build_user
+    user.save!
+    assert_equal "it", user.locale
+  end
+
+  test "explicit locale is preserved on create" do
+    user = build_user(locale: "en")
+    user.save!
+    assert_equal "en", user.locale
+  end
+
+  test "rejects locales other than it/en" do
+    user = build_user(locale: "fr")
+    refute user.valid?
+    assert_includes user.errors[:locale], "deve essere 'it' o 'en'"
+  end
+
+  test "accepts both supported locales" do
+    %w[it en].each do |loc|
+      assert build_user(locale: loc).valid?, "expected #{loc} to be valid"
+    end
+  end
+end


### PR DESCRIPTION
## Sommario
PR di follow-up sopra #32. Sistema un grosso problema strutturale in `it.yml` che rendeva ~70 traduzioni italiane irraggiungibili in produzione, completa le traduzioni mancanti, e aggiunge test che impediscono la regressione.

**Da mergiare/rebase su #32 prima del merge in main.**

## Il bug strutturale
In `it.yml`, le chiavi sotto `admin.payments.new` e `admin.payments.edit` erano accidentalmente nidate dentro `admin.users.edit`, e un blocco `users:` duplicato sotto `admin:` sovrascriveva silenziosamente il primo (Psych usa l'ultima definizione su chiavi duplicate). Risultato:

- ~30 chiavi `admin.payments.new.*` rendevano "translation missing" in italiano (la lingua di default)
- L'admin form per i nuovi pagamenti era praticamente illeggibile in IT
- 4 chiavi sotto `admin.users.edit` erano duplicati silenziosi

## Numeri prima/dopo l'audit

| | Prima | Dopo |
|---|---|---|
| Chiavi definite in en.yml | 849 | 858 |
| Chiavi definite in it.yml | 755 | 858 |
| Riferimenti `t(...)` mancanti in ENTRAMBI | 46 | 0 |
| Riferimenti mancanti solo in IT | 30 | 0 |
| Path duplicati (silently overridden) | 17 | 0 |
| Parità en ↔ it | 98 / 4 mismatch | piena parità |

## Modifiche al codice locale

**Restructure**:
- Sciolto il nesting sbagliato di `admin.payments.{new,edit}` in `it.yml`.
- Rimossi blocchi duplicati: `admin.users` in it.yml; `common` in entrambi (la mia aggiunta in cima sovrastampava il blocco esistente più sotto); `vehicle_label`/`route_label`/`distance_label`/`download_pdf` duplicati in `reimboursements.show` (entrambi i file).

**Aggiunte (46 chiavi mancanti in entrambi)**:
- `bank_accounts.{form, index, show, new}.*` per i bottoni view/edit/delete/cancel/save e i placeholder
- `vehicles.{form, index, show}.*` (stesso set)
- `funds.{index, show}.*` (view/edit/delete/cancel)
- `devise.passwords.new.*` (title/subtitle/email_label/email_placeholder/invalid_email/submit)
- `common.labels.distance` (unità "km")
- `errors.messages.not_saved` (con pluralizzazione one/other)
- `reimboursement.status` (singular - referenced from `_reimboursement.html.erb`)
- `roles.role.label`
- `admin.payments.{index, new}.*` per cancel/edit aggiuntivi
- `admin.users.{index, show}.*` per actions_th, view, edit, delete, status badge

**Quotate `"yes"`/`"no"`** (YAML 1.1 le interpretava come booleani `true:`/`false:`).

**Pulizia**:
- Rimossi 32 keys generici sotto `devise:` (label/messages/registrations actions) che erano duplicati di `common.actions/labels/messages` e mai referenziati. Erano stati apparentemente piazzati lì per errore.
- Rimossi 4 alias non usati in `admin.users.edit` (it.yml): `active_label`, `active_help`, `select_role`, `update_btn` — la view usa già le forme canoniche `account_active_label`, `account_active_help`, `select_role_prompt`, `update_user`.

## Test aggiunti

**`test/i18n_test.rb`** — 3 test (5 asserzioni):
1. Nessun path YAML duplicato (la trappola di sovrascrittura silenziosa che ha causato il bug).
2. Parità del set di chiavi tra en.yml e it.yml.
3. Ogni chiamata `t(...)` nel codebase risolve in entrambe le lingue, includendo lazy lookup `t(".foo")` (espansi dal path della view) e parent di pluralizzazione.

**`test/models/user_locale_test.rb`** — 4 test (7 asserzioni):
- Default locale "it" quando non esplicitato (DB default + callback before_create)
- Locale esplicito preservato
- Validazione rifiuta locale non supportate (es. "fr")
- Accetta sia "it" che "en"

**`test/controllers/set_locale_test.rb`** — 3 test (3 asserzioni):
- Usa `current_user.locale` quando presente
- Fallback a `I18n.default_locale` quando current_user è nil
- Fallback quando current_user.locale è nil

## Verifica
Tutti i test passano in container Docker con Postgres 16 + Ruby 3.2.2:
```
test/i18n_test.rb              3 runs, 5 assertions, 0 failures, 0 errors
test/models/user_locale_test.rb 4 runs, 7 assertions, 0 failures, 0 errors
test/controllers/set_locale_test.rb 3 runs, 3 assertions, 0 failures, 0 errors
```

## Test plan
- [ ] Mergiare/rebase su #32 prima del merge in main.
- [x] Aprire l'app in italiano, andare su `/admin/payments/new` → controllare che tutte le label siano in italiano (era il bug più visibile).
- [ ] Cambiare locale utente a `en` dal profilo, navigare le stesse pagine → tutto in inglese.
- [ ] `bin/rails test test/i18n_test.rb` deve passare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)